### PR TITLE
Add streaming and during_call support

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/panw_prisma_airs.md
+++ b/docs/my-website/docs/proxy/guardrails/panw_prisma_airs.md
@@ -14,6 +14,8 @@ LiteLLM supports PANW Prisma AIRS (AI Runtime Security) guardrails via the [Pris
 - ✅ **Comprehensive threat detection** for AI models and datasets
 - ✅ **Model-agnostic protection** across public and private models
 - ✅ **Synchronous scanning** with immediate response
+- ✅ **Streaming support** - Real-time scanning with configurable chunk sizes
+- ✅ **Incremental scanning** - Process streaming responses at configurable intervals
 - ✅ **Configurable security profiles**
 
 ## Quick Start
@@ -44,13 +46,17 @@ guardrails:
       mode: "pre_call"                    # Run before LLM call
       api_key: os.environ/AIRS_API_KEY    # Your PANW API key
       profile_name: os.environ/AIRS_API_PROFILE_NAME  # Security profile from Strata Cloud Manager
-      api_base: "https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request"  # Optional
+
+      # The following variables are optional
+      api_base: "https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request"  
+      incremental_scan_chunk_size: 50      # Scan every 50 chars (0 = scan only at end, default 0)
+      disable_streaming_check: False         # Set true to skip streaming scans, only run post_call_success_hook. default False.
 ```
 
 #### Supported values for `mode`
 
 - `pre_call` Run **before** LLM call, on **input**
-- `post_call` Run **after** LLM call, on **input & output**  
+- `post_call` Run **after** LLM call, on **output**  
 - `during_call` Run **during** LLM call, on **input**. Same as `pre_call` but runs in parallel with LLM call
 
 ### 3. Start LiteLLM Gateway
@@ -199,6 +205,8 @@ Expected successful response:
 | `profile_name` | Yes | Security profile name configured in Strata Cloud Manager | - |
 | `api_base` | No | Custom API endpoint | `https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request` |
 | `mode` | No | When to run the guardrail | `pre_call` |
+| `incremental_scan_chunk_size` | No | Run scan every XX chars. If set to 0, only scan at the end | 0 |
+| `disable_streaming_check` | No | Whether to skip streaming scans | False |
 
 ## Environment Variables
 


### PR DESCRIPTION
##  Streaming mode support
**feat: add support for streaming mode via `async_post_call_streaming_iterator_hook`**

Introduced two new configuration flags:

- `disable_streaming_check` – controls whether the hook is invoked at all in streaming mode.  
- `incremental_scan_chunk_size` – the number of characters to accumulate before performing an incremental scan; if a violation is found the stream is aborted immediately. Set to `0` to defer scanning until the complete response is assembled.

When LiteLLM is configured with `post_call` enabled:
- Non-streaming completions invoke `async_post_call_success_hook`.  
- Streaming completions invoke `async_post_call_streaming_iterator_hook`, and the new flags let users toggle or fine-tune this behavior.

##  during_call support
**feat: add support for during-call scanning via `async_moderation_hook`**

Introduced `async_moderation_hook` to perform real-time content scanning **while the request is being processed** (i.e., **during_call**).  
This hook is invoked after the prompt is received.

##  Document
**docs: update documentation for the new features**

Document the newly introduced `disable_streaming_check` and `incremental_scan_chunk_size` parameters, as well as the `async_post_call_streaming_iterator_hook` and `async_moderation_hook` capabilities, in the user-facing docs.



